### PR TITLE
Fix ingress template hostname reference for TLS configuration

### DIFF
--- a/charts/infrahub/templates/infrahub-server-ingress.yaml
+++ b/charts/infrahub/templates/infrahub-server-ingress.yaml
@@ -54,8 +54,8 @@ spec:
     - hosts:
       - {{ .Values.infrahubServer.ingress.hostname }}
       {{- range .Values.infrahubServer.ingress.extraHosts }}
-        {{- if .name }}
-      -  {{ .name }}
+        {{- if .hostname }}
+      - {{ .hostname }}
         {{- end }}
       {{- end }}
       secretName: infrahub-server-tls


### PR DESCRIPTION
This change corrects the field reference from .name to .hostname in the infrahub-server-ingress.yaml template to properly configure TLS certificates for extra hosts.