### PR TITLE
fix: omit default tokens when empty

### DIFF
--- a/charts/infrahub-enterprise/Chart.yaml
+++ b/charts/infrahub-enterprise/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.2
+version: 4.2.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -27,5 +27,5 @@ appVersion: "1.7.6"
 
 dependencies:
   - name: infrahub
-    version: "4.16.2"
+    version: "4.16.3"
     repository: "oci://registry.opsmill.io/opsmill/chart"

--- a/charts/infrahub-enterprise/README.md
+++ b/charts/infrahub-enterprise/README.md
@@ -58,7 +58,7 @@ The chart offers the ability to configure persistence for the database and other
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.16.0 |
+| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.16.3 |
 
 ## Values
 

--- a/charts/infrahub/Chart.yaml
+++ b/charts/infrahub/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.16.2
+version: 4.16.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/infrahub/README.md
+++ b/charts/infrahub/README.md
@@ -163,7 +163,7 @@ The chart offers the ability to configure persistence for the database and other
 | neo4j.volumes.data.mode | string | `"volume"` |  |
 | neo4j.volumes.data.volume.emptyDir | object | `{}` |  |
 | prefect-server.enabled | bool | `true` |  |
-| prefect-server.global.prefect.image.prefectTag | string | `"1.7.4"` |  |
+| prefect-server.global.prefect.image.prefectTag | string | `"1.7.6"` |  |
 | prefect-server.global.prefect.image.repository | string | `"registry.opsmill.io/opsmill/infrahub"` |  |
 | prefect-server.postgresql.enabled | bool | `true` |  |
 | prefect-server.postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |

--- a/charts/infrahub/templates/emma.yaml
+++ b/charts/infrahub/templates/emma.yaml
@@ -36,8 +36,10 @@ spec:
           env:
             {{- include "infrahub-helm.emma.defaultEnv" . | nindent 12 }}
             {{- range $key, $value := .Values.emma.env }}
+            {{- if or $value (not (or (eq $key "INFRAHUB_INITIAL_ADMIN_TOKEN") (eq $key "INFRAHUB_SECURITY_SECRET_KEY") (eq $key "INFRAHUB_API_TOKEN"))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- with .Values.emma.envFromExistingSecret }}
           envFrom:

--- a/charts/infrahub/templates/infrahub-demo-data-job.yaml
+++ b/charts/infrahub/templates/infrahub-demo-data-job.yaml
@@ -23,8 +23,10 @@ spec:
           {{- include "infrahub-helm.infrahubDemoData.defaultEnv" . | nindent 12 }}
           {{- with .Values.infrahubDemoData.env }}
             {{- range $key, $value := . }}
+            {{- if or $value (not (or (eq $key "INFRAHUB_INITIAL_ADMIN_TOKEN") (eq $key "INFRAHUB_SECURITY_SECRET_KEY") (eq $key "INFRAHUB_API_TOKEN"))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- end }}
           {{- with .Values.infrahubServer.infrahubServer.envFromExistingSecret }}

--- a/charts/infrahub/templates/infrahub-server.yaml
+++ b/charts/infrahub/templates/infrahub-server.yaml
@@ -48,8 +48,10 @@ spec:
           env:
             {{- include "infrahub-helm.infrahubServer.defaultEnv" . | nindent 12 }}
             {{- range $key, $value := .Values.infrahubServer.infrahubServer.env }}
+            {{- if or $value (not (or (eq $key "INFRAHUB_INITIAL_ADMIN_TOKEN") (eq $key "INFRAHUB_SECURITY_SECRET_KEY") (eq $key "INFRAHUB_API_TOKEN"))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- if and .Values.infrahubServer.infrahubServer.envFromExistingSecret .Values.infrahubServer.infrahubServer.envFromExistingSecrets }}
             {{- fail "infrahubServer.infrahubServer.envFromExistingSecret and infrahubServer.infrahubServer.envFromExistingSecrets are mutually exclusive. Please use envFromExistingSecrets (envFromExistingSecret is deprecated)." }}

--- a/charts/infrahub/templates/infrahub-task-worker.yaml
+++ b/charts/infrahub/templates/infrahub-task-worker.yaml
@@ -49,8 +49,10 @@ spec:
           env:
             {{- include "infrahub-helm.infrahubTaskWorker.defaultEnv" . | nindent 12 }}
             {{- range $key, $value := .Values.infrahubTaskWorker.infrahubTaskWorker.env }}
+            {{- if or $value (not (or (eq $key "INFRAHUB_INITIAL_ADMIN_TOKEN") (eq $key "INFRAHUB_SECURITY_SECRET_KEY") (eq $key "INFRAHUB_API_TOKEN"))) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- if and .Values.infrahubTaskWorker.infrahubTaskWorker.envFromExistingSecret .Values.infrahubTaskWorker.infrahubTaskWorker.envFromExistingSecrets }}
             {{- fail "infrahubTaskWorker.infrahubTaskWorker.envFromExistingSecret and infrahubTaskWorker.infrahubTaskWorker.envFromExistingSecrets are mutually exclusive. Please use envFromExistingSecrets (envFromExistingSecret is deprecated)." }}


### PR DESCRIPTION
This is a workaround for an ArgoCD issue where we cannot nullify those variables. Instead empty values are pushed through the values. This change ensures the variables are omitted when the value is an empty string.