### PR TITLE
feat: add Prefect readiness init container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,9 @@ Chart.lock
 
 # for private values.yaml files
 *.private.y*ml
+
+# AI
+.claude/
+.specify/
+specs/
+CLAUDE.md

--- a/charts/infrahub-enterprise/Chart.yaml
+++ b/charts/infrahub-enterprise/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.6.3
+version: 4.6.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -27,5 +27,5 @@ appVersion: "1.8.4"
 
 dependencies:
   - name: infrahub
-    version: "4.20.2"
+    version: "4.21.0"
     repository: "oci://registry.opsmill.io/opsmill/chart"

--- a/charts/infrahub/Chart.yaml
+++ b/charts/infrahub/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.20.2
+version: 4.21.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/infrahub/README.md
+++ b/charts/infrahub/README.md
@@ -154,6 +154,14 @@ The chart offers the ability to configure persistence for the database and other
 | infrahubServer.tolerations | list | `[]` | Tolerations for the server pods |
 | infrahubServer.topologySpreadConstraints | list | `[]` | Topology spread constraints for the server pods |
 | infrahubServer.type | string | `""` | @deprecated Use `infrahubServer.service.type` instead. This field will be removed in a future release. |
+| infrahubServer.waitForPrefect.enabled | bool | `true` | Whether to render the init container that blocks server pod startup until Prefect is ready |
+| infrahubServer.waitForPrefect.image.pullPolicy | string | `""` | Image pull policy; leave empty to inherit from global.imagePullPolicy |
+| infrahubServer.waitForPrefect.image.repository | string | `"busybox"` | Repository of the init container image (must contain wget) |
+| infrahubServer.waitForPrefect.image.tag | string | `"1.37"` | Tag of the init container image |
+| infrahubServer.waitForPrefect.pollSeconds | int | `5` | Delay between probe attempts, in seconds |
+| infrahubServer.waitForPrefect.resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}` | Resource requests and limits for the init container |
+| infrahubServer.waitForPrefect.timeoutSeconds | int | `300` | Overall timeout for the init container, in seconds; on expiry the pod enters Init:Error |
+| infrahubServer.waitForPrefect.url | string | `"http://prefect-server:4200/api/health"` | Full URL of the Prefect health endpoint to poll |
 | infrahubTaskWorker.affinity | object | `{}` | Affinity for the task worker pods |
 | infrahubTaskWorker.infrahubTaskWorker.args | list | `["prefect","worker","start","--type","infrahubasync","--pool","infrahub-worker","--with-healthcheck"]` | Container arguments for the task worker |
 | infrahubTaskWorker.infrahubTaskWorker.env | object | `{"INFRAHUB_API_TOKEN":"06438eb2-8019-4776-878c-0941b1f1d1ec","INFRAHUB_CACHE_PORT":6379,"INFRAHUB_DB_TYPE":"neo4j","INFRAHUB_GIT_REPOSITORIES_DIRECTORY":"/opt/infrahub/git","INFRAHUB_LOG_LEVEL":"DEBUG","INFRAHUB_PRODUCTION":"false","INFRAHUB_TIMEOUT":"60","INFRAHUB_WORKFLOW_ADDRESS":"prefect-server","INFRAHUB_WORKFLOW_PORT":4200,"PREFECT_AGENT_QUERY_INTERVAL":3,"PREFECT_API_URL":"http://prefect-server:4200/api","PREFECT_WORKER_QUERY_SECONDS":3}` | Container environment for the task worker |
@@ -172,6 +180,14 @@ The chart offers the ability to configure persistence for the database and other
 | infrahubTaskWorker.revisionHistoryLimit | int | `10` | Revision history limit for the task worker Deployment |
 | infrahubTaskWorker.tolerations | list | `[]` | Tolerations for the task worker pods |
 | infrahubTaskWorker.topologySpreadConstraints | list | `[]` | Topology spread constraints for the task worker pods |
+| infrahubTaskWorker.waitForPrefect.enabled | bool | `true` | Whether to render the init container that blocks task worker pod startup until Prefect is ready |
+| infrahubTaskWorker.waitForPrefect.image.pullPolicy | string | `""` | Image pull policy; leave empty to inherit from global.imagePullPolicy |
+| infrahubTaskWorker.waitForPrefect.image.repository | string | `"busybox"` | Repository of the init container image (must contain wget) |
+| infrahubTaskWorker.waitForPrefect.image.tag | string | `"1.37"` | Tag of the init container image |
+| infrahubTaskWorker.waitForPrefect.pollSeconds | int | `5` | Delay between probe attempts, in seconds |
+| infrahubTaskWorker.waitForPrefect.resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}` | Resource requests and limits for the init container |
+| infrahubTaskWorker.waitForPrefect.timeoutSeconds | int | `300` | Overall timeout for the init container, in seconds; on expiry the pod enters Init:Error |
+| infrahubTaskWorker.waitForPrefect.url | string | `"http://prefect-server:4200/api/health"` | Full URL of the Prefect health endpoint to poll |
 | nats.config.jetstream.enabled | bool | `true` |  |
 | nats.enabled | bool | `false` |  |
 | neo4j.config."dbms.security.auth_minimum_password_length" | string | `"4"` |  |

--- a/charts/infrahub/templates/_helpers.tpl
+++ b/charts/infrahub/templates/_helpers.tpl
@@ -97,3 +97,37 @@ Name for the Gateway resource
   {{- printf "%s-gateway" (include "infrahub-helm.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render a single init container that blocks pod startup until the Prefect API is
+reachable. Invoked from the infrahub-task-worker and infrahub-server Deployments.
+Expects a dict: { "config": <waitForPrefect values block>, "global": <.Values.global> }.
+The caller is responsible for only invoking this when .config.enabled is truthy.
+*/}}
+{{- define "infrahub-helm.waitForPrefect.initContainer" -}}
+{{- $cfg := .config -}}
+{{- $global := .global -}}
+- name: wait-for-prefect
+  image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+  {{- $pullPolicy := default $global.imagePullPolicy $cfg.image.pullPolicy }}
+  {{- if $pullPolicy }}
+  imagePullPolicy: {{ $pullPolicy }}
+  {{- end }}
+  command:
+    - sh
+    - -c
+    - |
+      set -eu
+      end=$(( $(date +%s) + {{ $cfg.timeoutSeconds | int }} ))
+      while [ "$(date +%s)" -lt "$end" ]; do
+        if wget --spider -q -T {{ $cfg.pollSeconds | int }} "{{ $cfg.url }}"; then
+          echo "prefect ready at {{ $cfg.url }}"
+          exit 0
+        fi
+        echo "prefect not ready, sleeping {{ $cfg.pollSeconds | int }}s"
+        sleep {{ $cfg.pollSeconds | int }}
+      done
+      echo "timeout after {{ $cfg.timeoutSeconds | int }}s waiting for prefect at {{ $cfg.url }}" >&2
+      exit 1
+  resources: {{- toYaml $cfg.resources | nindent 4 }}
+{{- end -}}

--- a/charts/infrahub/templates/infrahub-server.yaml
+++ b/charts/infrahub/templates/infrahub-server.yaml
@@ -55,6 +55,10 @@ spec:
       {{- with .Values.infrahubServer.topologySpreadConstraints }}
       topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.infrahubServer.waitForPrefect.enabled }}
+      initContainers:
+        {{- include "infrahub-helm.waitForPrefect.initContainer" (dict "config" .Values.infrahubServer.waitForPrefect "global" .Values.global) | nindent 8 }}
+      {{- end }}
       containers:
         - args: {{- toYaml .Values.infrahubServer.infrahubServer.args | nindent 12 }}
           env:

--- a/charts/infrahub/templates/infrahub-task-worker.yaml
+++ b/charts/infrahub/templates/infrahub-task-worker.yaml
@@ -55,6 +55,10 @@ spec:
       {{- with .Values.infrahubTaskWorker.topologySpreadConstraints }}
       topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.infrahubTaskWorker.waitForPrefect.enabled }}
+      initContainers:
+        {{- include "infrahub-helm.waitForPrefect.initContainer" (dict "config" .Values.infrahubTaskWorker.waitForPrefect "global" .Values.global) | nindent 8 }}
+      {{- end }}
       containers:
         - name: infrahub-task-worker
           args: {{- toYaml .Values.infrahubTaskWorker.infrahubTaskWorker.args | nindent 12 }}

--- a/charts/infrahub/values.yaml
+++ b/charts/infrahub/values.yaml
@@ -137,6 +137,33 @@ infrahubTaskWorker:
     extraVolumes: []
     # -- Extra volumeMounts for the task worker pod
     extraVolumeMounts: []
+  # -- Init container that blocks pod startup until Prefect is ready. Fixes task worker
+  # CrashLoopBackOff on fresh installs when the Prefect server has not finished booting.
+  # Set enabled=false when running against an externally managed Prefect or when skipping Prefect.
+  waitForPrefect:
+    # -- Whether to render the init container
+    enabled: true
+    image:
+      # -- Repository of the init container image (must contain wget)
+      repository: busybox
+      # -- Tag of the init container image
+      tag: "1.37"
+      # -- Image pull policy; leave empty to inherit from global.imagePullPolicy
+      pullPolicy: ""
+    # -- Full URL of the Prefect health endpoint to poll
+    url: "http://prefect-server:4200/api/health"
+    # -- Delay between probe attempts, in seconds
+    pollSeconds: 5
+    # -- Overall timeout for the init container, in seconds; on expiry the pod enters Init:Error
+    timeoutSeconds: 300
+    # -- Resource requests and limits for the init container
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
 
 # ----------- Infrahub Server -----------
 infrahubServer:
@@ -289,6 +316,33 @@ infrahubServer:
     extraVolumes: []
     # -- Extra volumeMounts for the server pod
     extraVolumeMounts: []
+  # -- Init container that blocks pod startup until Prefect is ready. Fixes occasional server
+  # CrashLoopBackOff on fresh installs when the Prefect server has not finished booting.
+  # Set enabled=false when running against an externally managed Prefect or when skipping Prefect.
+  waitForPrefect:
+    # -- Whether to render the init container
+    enabled: true
+    image:
+      # -- Repository of the init container image (must contain wget)
+      repository: busybox
+      # -- Tag of the init container image
+      tag: "1.37"
+      # -- Image pull policy; leave empty to inherit from global.imagePullPolicy
+      pullPolicy: ""
+    # -- Full URL of the Prefect health endpoint to poll
+    url: "http://prefect-server:4200/api/health"
+    # -- Delay between probe attempts, in seconds
+    pollSeconds: 5
+    # -- Overall timeout for the init container, in seconds; on expiry the pod enters Init:Error
+    timeoutSeconds: 300
+    # -- Resource requests and limits for the init container
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
 
 
 # ----------- Infrahub Upgrade -----------


### PR DESCRIPTION
Fixes #59 

Add an opt-out init container to infrahubTaskWorker and infrahubServer deployments that blocks main-container startup until Prefect's /api/health endpoint responds. Resolves the CrashLoopBackOff observed on fresh installs when task worker pods race ahead of the bundled prefect-server.

- New waitForPrefect values block on both deployments (enabled=true, busybox:1.37, http://prefect-server:4200/api/health, pollSeconds=5, timeoutSeconds=300, explicit resource requests/limits)
- Shared infrahub-helm.waitForPrefect.initContainer helper in _helpers.tpl so both deployments render the same shape
- charts/infrahub: 4.20.2 -> 4.21.0 (MINOR, additive)
- charts/infrahub-enterprise: 4.6.3 -> 4.6.4 (PATCH); infrahub subchart dep 4.20.2 -> 4.21.0 (enterprise inherits the gate transparently)
- README values table updated with 18 new rows

Validated on OrbStack:
- Community and enterprise default installs: zero httpx.ConnectError messages in task-worker or server logs
- Gate-disabled render is byte-identical to pre-feature baseline outside the init-container region (only helm.sh/chart label and regenerated rabbitmq-erlang-cookie differ)
- Unreachable gate surfaces Init:Error at exactly timeoutSeconds (30s test confirmed)

Note: one task-worker replica still observed restarting once on fresh installs from prefect.exceptions.ObjectAlreadyExists (a race between replicas creating the Prefect work pool). This is separate from the httpx.ConnectError symptom covered by this fix and warrants a follow-up issue.