### PR TITLE
feat: add infrahub-mcp Helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       enterprise: ${{ steps.filter.outputs.enterprise }}
       backup: ${{ steps.filter.outputs.backup }}
       observability: ${{ steps.filter.outputs.observability }}
+      mcp: ${{ steps.filter.outputs.mcp }}
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - uses: "actions/checkout@v4"
@@ -38,6 +39,9 @@ jobs:
               - 'charts/infrahub-backup/**'
             observability:
               - 'charts/infrahub-observability/**'
+            mcp:
+              - 'charts/infrahub-mcp/**'
+              - 'charts/infrahub/**'
             e2e:
               - 'tests/**'
               - 'pyproject.toml'
@@ -84,6 +88,19 @@ jobs:
         run: "helm dependency update charts/infrahub-observability"
       - name: "Linting: helm lint infrahub-observability"
         run: "helm lint charts/infrahub-observability"
+
+  helm-lint-mcp:
+    needs: changes
+    if: ${{ needs.changes.outputs.mcp == 'true' }}
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 5
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: true
+      - uses: "azure/setup-helm@v4.3.0"
+      - name: "Linting: helm lint infrahub-mcp"
+        run: "helm lint charts/infrahub-mcp"
 
   # ---------------------------------------------------------------------------
   # End-to-end tests. Each chart has its own job, deployed into a throwaway
@@ -158,3 +175,17 @@ jobs:
         run: "./scripts/sync-upstream.sh"
       - name: "Run e2e tests: infrahub-observability"
         run: "uv run pytest -v -m observability tests/e2e"
+
+  e2e-infrahub-mcp:
+    needs: changes
+    if: ${{ needs.changes.outputs.mcp == 'true' || needs.changes.outputs.e2e == 'true' }}
+    runs-on:
+      group: huge-runners
+    timeout-minutes: 40
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: true
+      - uses: "./.github/actions/setup-e2e"
+      - name: "Run e2e tests: infrahub-mcp"
+        run: "uv run pytest -v -m mcp tests/e2e"

--- a/charts/infrahub-enterprise/Chart.yaml
+++ b/charts/infrahub-enterprise/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.9.0
+version: 4.10.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -27,5 +27,5 @@ appVersion: "1.9.7"
 
 dependencies:
   - name: infrahub
-    version: "4.23.0"
+    version: "4.24.0"
     repository: "oci://registry.opsmill.io/opsmill/chart"

--- a/charts/infrahub-enterprise/README.md
+++ b/charts/infrahub-enterprise/README.md
@@ -58,7 +58,7 @@ The chart offers the ability to configure persistence for the database and other
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.23.0 |
+| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.24.0 |
 
 ## Values
 

--- a/charts/infrahub-mcp/Chart.yaml
+++ b/charts/infrahub-mcp/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
     url: https://github.com/opsmill
 type: application
 version: 0.1.0
-appVersion: "v1.1.5"
+appVersion: "v1.1.6"

--- a/charts/infrahub-mcp/Chart.yaml
+++ b/charts/infrahub-mcp/Chart.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v2
+name: infrahub-mcp
+description: Helm chart for Infrahub MCP Server on Kubernetes
+icon: https://github.com/opsmill/infrahub/raw/develop/frontend/app/public/favicons/logo512.png
+home: https://github.com/opsmill/infrahub-helm
+sources:
+  - https://github.com/opsmill/infrahub-mcp
+keywords:
+  - infrahub
+  - mcp
+  - model-context-protocol
+  - ai
+  - agent
+maintainers:
+  - name: OpsMill
+    url: https://github.com/opsmill
+type: application
+version: 0.1.0
+appVersion: "0.6.0"

--- a/charts/infrahub-mcp/Chart.yaml
+++ b/charts/infrahub-mcp/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
     url: https://github.com/opsmill
 type: application
 version: 0.1.0
-appVersion: "0.6.0"
+appVersion: "1.1.0"

--- a/charts/infrahub-mcp/Chart.yaml
+++ b/charts/infrahub-mcp/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
     url: https://github.com/opsmill
 type: application
 version: 0.1.0
-appVersion: "1.1.0"
+appVersion: "v1.1.5"

--- a/charts/infrahub-mcp/README.md
+++ b/charts/infrahub-mcp/README.md
@@ -18,14 +18,40 @@ Helm chart for Infrahub MCP Server on Kubernetes
 | envFromExistingSecrets | list | `[]` | Name of existing Secret(s) to load as environment variables |
 | extraEnv | object | `{}` | Additional environment variables (key: value pairs) |
 | fullnameOverride | string | `""` | Override the full name |
+| gatewayApi | object | `{"enabled":false,"gateway":{"annotations":{},"className":"","enabled":false,"labels":{},"listeners":[],"name":""},"httpRoute":{"annotations":{},"extraRules":[],"hostnames":[],"labels":{},"name":"","parentRefs":[],"path":"/mcp"}}` | Gateway API configuration for the MCP server. ref: https://gateway-api.sigs.k8s.io/ Mutually exclusive with `ingress`. |
+| gatewayApi.enabled | bool | `false` | Whether to enable Gateway API HTTPRoute for the MCP server |
+| gatewayApi.gateway.annotations | object | `{}` | Additional annotations for the Gateway resource |
+| gatewayApi.gateway.className | string | `""` | GatewayClass name (required when gateway.enabled is true) |
+| gatewayApi.gateway.enabled | bool | `false` | Whether to create a Gateway resource (most users will reference an existing Gateway via httpRoute.parentRefs) |
+| gatewayApi.gateway.labels | object | `{}` | Additional labels for the Gateway resource |
+| gatewayApi.gateway.listeners | list | `[]` | Gateway listeners configuration |
+| gatewayApi.gateway.name | string | `""` | Gateway resource name (defaults to "<fullname>-gateway") |
+| gatewayApi.httpRoute.annotations | object | `{}` | Additional annotations for the HTTPRoute resource |
+| gatewayApi.httpRoute.extraRules | list | `[]` | Additional HTTPRoute rules beyond the auto-generated one |
+| gatewayApi.httpRoute.hostnames | list | `[]` | Hostnames that this HTTPRoute should match |
+| gatewayApi.httpRoute.labels | object | `{}` | Additional labels for the HTTPRoute resource |
+| gatewayApi.httpRoute.name | string | `""` | HTTPRoute resource name (defaults to "<fullname>-httproute") |
+| gatewayApi.httpRoute.parentRefs | list | `[]` | Parent Gateway references |
+| gatewayApi.httpRoute.path | string | `"/mcp"` | Path prefix for the default matching rule |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"registry.opsmill.io/opsmill/infrahub-mcp","tag":""}` | Container image configuration |
 | image.tag | string | `""` | Tag defaults to chart appVersion if not specified |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
-| infrahub | object | `{"address":"","apiToken":"","existingSecret":"","existingSecretKey":"INFRAHUB_API_TOKEN"}` | Infrahub connection settings |
-| infrahub.address | string | `""` | Infrahub server address (auto-configured when used as sub-chart) |
-| infrahub.apiToken | string | `""` | API token for authenticating with Infrahub |
-| infrahub.existingSecret | string | `""` | Name of an existing Secret containing INFRAHUB_API_TOKEN |
-| infrahub.existingSecretKey | string | `"INFRAHUB_API_TOKEN"` | Key within the existing Secret that holds the API token |
+| infrahub | object | `{"address":"","apiToken":{"existingSecret":"","existingSecretKey":"INFRAHUB_API_TOKEN","value":""}}` | Infrahub connection settings |
+| infrahub.address | string | `""` | Infrahub server address (e.g. "http://infrahub-infrahub-server:8000") |
+| infrahub.apiToken | object | `{"existingSecret":"","existingSecretKey":"INFRAHUB_API_TOKEN","value":""}` | API token for authenticating with Infrahub |
+| infrahub.apiToken.existingSecret | string | `""` | Name of an existing Secret containing the API token. Takes precedence over `value` when set. |
+| infrahub.apiToken.existingSecretKey | string | `"INFRAHUB_API_TOKEN"` | Key within the existing Secret that holds the API token |
+| infrahub.apiToken.value | string | `""` | API token value, rendered as a plain-text env var. Prefer `existingSecret` for production deployments. |
+| ingress | object | `{"annotations":{},"enabled":false,"extraHosts":[],"extraTls":[],"hostname":"","ingressClassName":"","path":"/mcp","pathType":"Prefix","tls":false}` | Ingress configuration for exposing the MCP server externally. To serve the MCP server on the same host as Infrahub (e.g. under a "/mcp" path prefix), set `hostname` to the Infrahub server's ingress hostname and keep the default `path`. |
+| ingress.annotations | object | `{}` | Annotations to configure on the ingress |
+| ingress.enabled | bool | `false` | Whether to enable Ingress for the MCP server |
+| ingress.extraHosts | list | `[]` | Additional hosts to expose (each entry: hostname, path, pathType) |
+| ingress.extraTls | list | `[]` | Additional TLS configuration entries (raw `tls` list items) |
+| ingress.hostname | string | `""` | Hostname to configure for the ingress |
+| ingress.ingressClassName | string | `""` | IngressClass name to use |
+| ingress.path | string | `"/mcp"` | Path prefix under which the MCP server is exposed |
+| ingress.pathType | string | `"Prefix"` | PathType for the ingress rule |
+| ingress.tls | bool | `false` | Enable TLS for `hostname` using the secret "<fullname>-tls" |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
 | mcp | object | `{"authMode":"none","branching":{"maxRetries":5,"pattern":"mcp/session-{date}-{hex}"},"cache":{"enabled":false,"listTtl":300,"readTtl":3600},"dereferenceSchemas":false,"logLevel":"info","observability":{"otelEnabled":false,"pingIntervalMs":0,"prometheusEnabled":false},"rateLimit":{"burst":0,"rps":0},"readOnly":false,"retry":{"baseDelay":1,"maxAttempts":0}}` | MCP server configuration |
 | mcp.authMode | string | `"none"` | Authentication mode: "none", "token-passthrough", "basic-passthrough", "oidc" |

--- a/charts/infrahub-mcp/README.md
+++ b/charts/infrahub-mcp/README.md
@@ -1,0 +1,74 @@
+# infrahub-mcp
+
+Helm chart for Infrahub MCP Server on Kubernetes
+
+**Homepage:** <https://github.com/opsmill/infrahub-helm>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| OpsMill |  | <https://github.com/opsmill> |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling |
+| envFromExistingSecrets | list | `[]` | Name of existing Secret(s) to load as environment variables |
+| extraEnv | object | `{}` | Additional environment variables (key: value pairs) |
+| fullnameOverride | string | `""` | Override the full name |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"registry.opsmill.io/opsmill/infrahub-mcp","tag":""}` | Container image configuration |
+| image.tag | string | `""` | Tag defaults to chart appVersion if not specified |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries |
+| infrahub | object | `{"address":"","apiToken":"","existingSecret":"","existingSecretKey":"INFRAHUB_API_TOKEN"}` | Infrahub connection settings |
+| infrahub.address | string | `""` | Infrahub server address (auto-configured when used as sub-chart) |
+| infrahub.apiToken | string | `""` | API token for authenticating with Infrahub |
+| infrahub.existingSecret | string | `""` | Name of an existing Secret containing INFRAHUB_API_TOKEN |
+| infrahub.existingSecretKey | string | `"INFRAHUB_API_TOKEN"` | Key within the existing Secret that holds the API token |
+| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| mcp | object | `{"authMode":"none","branching":{"maxRetries":5,"pattern":"mcp/session-{date}-{hex}"},"cache":{"enabled":false,"listTtl":300,"readTtl":3600},"dereferenceSchemas":false,"logLevel":"info","observability":{"otelEnabled":false,"pingIntervalMs":0,"prometheusEnabled":false},"rateLimit":{"burst":0,"rps":0},"readOnly":false,"retry":{"baseDelay":1,"maxAttempts":0}}` | MCP server configuration |
+| mcp.authMode | string | `"none"` | Authentication mode: "none", "token-passthrough", "basic-passthrough", "oidc" |
+| mcp.branching | object | `{"maxRetries":5,"pattern":"mcp/session-{date}-{hex}"}` | Branching configuration |
+| mcp.branching.maxRetries | int | `5` | Max retries for branch creation on name collision |
+| mcp.branching.pattern | string | `"mcp/session-{date}-{hex}"` | Branch name pattern for auto-created branches |
+| mcp.cache | object | `{"enabled":false,"listTtl":300,"readTtl":3600}` | Caching configuration |
+| mcp.cache.enabled | bool | `false` | Enable response caching |
+| mcp.cache.listTtl | int | `300` | TTL in seconds for list operations |
+| mcp.cache.readTtl | int | `3600` | TTL in seconds for read operations |
+| mcp.dereferenceSchemas | bool | `false` | Enable JSON $ref dereferencing in schemas |
+| mcp.logLevel | string | `"info"` | Log level: "debug", "info", "warning", "error" |
+| mcp.observability | object | `{"otelEnabled":false,"pingIntervalMs":0,"prometheusEnabled":false}` | Observability configuration |
+| mcp.observability.otelEnabled | bool | `false` | Enable OpenTelemetry tracing |
+| mcp.observability.pingIntervalMs | int | `0` | Ping keepalive interval in milliseconds (0 = disabled) |
+| mcp.observability.prometheusEnabled | bool | `false` | Enable Prometheus metrics endpoint |
+| mcp.rateLimit | object | `{"burst":0,"rps":0}` | Rate limiting configuration |
+| mcp.rateLimit.burst | int | `0` | Burst allowance (0 = disabled) |
+| mcp.rateLimit.rps | int | `0` | Requests per second (0 = disabled) |
+| mcp.readOnly | bool | `false` | Enable read-only mode (blocks all write operations) |
+| mcp.retry | object | `{"baseDelay":1,"maxAttempts":0}` | Retry configuration |
+| mcp.retry.baseDelay | int | `1` | Base delay between retries in seconds |
+| mcp.retry.maxAttempts | int | `0` | Max retry attempts (0 = disabled) |
+| nameOverride | string | `""` | Override the chart name |
+| nodeSelector | object | `{}` | Node selector for pod scheduling |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":1000}` | Pod security context |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe configuration |
+| replicaCount | int | `1` | Number of replicas |
+| resources | object | `{}` | Resource limits and requests |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container security context |
+| service | object | `{"port":8001,"targetPort":8001,"type":"ClusterIP"}` | Service configuration |
+| service.port | int | `8001` | Service port |
+| service.targetPort | int | `8001` | Container target port |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | ServiceAccount configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount (auto-generated if empty) |
+| tolerations | list | `[]` | Tolerations for pod scheduling |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)
+
+For more detailed configuration and additional parameters, refer to the `values.yaml` file.

--- a/charts/infrahub-mcp/README.md.gotmpl
+++ b/charts/infrahub-mcp/README.md.gotmpl
@@ -1,0 +1,14 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+
+For more detailed configuration and additional parameters, refer to the `values.yaml` file.

--- a/charts/infrahub-mcp/templates/NOTES.txt
+++ b/charts/infrahub-mcp/templates/NOTES.txt
@@ -1,13 +1,31 @@
 Infrahub MCP Server has been deployed.
 
+{{- if .Values.ingress.enabled }}
+
+The MCP server is exposed via Ingress. Connect your MCP client to:
+{{- $scheme := ternary "https" "http" (or .Values.ingress.tls (gt (len .Values.ingress.extraTls) 0)) }}
+{{- $path := trimSuffix "/" .Values.ingress.path }}
+  {{ $scheme }}://{{ .Values.ingress.hostname }}{{ $path }}/mcp
+{{- else if .Values.gatewayApi.enabled }}
+
+The MCP server is exposed via the Gateway API (HTTPRoute).
+{{- with .Values.gatewayApi.httpRoute.hostnames }}
+Connect your MCP client to (path prefix {{ $.Values.gatewayApi.httpRoute.path | default "/mcp" }}):
+  {{- range . }}
+  http://{{ . }}{{ trimSuffix "/" ($.Values.gatewayApi.httpRoute.path | default "/mcp") }}/mcp
+  {{- end }}
+{{- end }}
+{{- else }}
+
 Get the MCP server URL by running:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "infrahub-mcp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.targetPort }}
 
 Then connect your MCP client to:
   http://localhost:{{ .Values.service.port }}/mcp
+{{- end }}
 
 Configuration:
   Auth mode:  {{ .Values.mcp.authMode }}
   Read-only:  {{ .Values.mcp.readOnly }}
-  Infrahub:   {{ .Values.infrahub.address | default "auto-configured via sub-chart" }}
+  Infrahub:   {{ .Values.infrahub.address | default "(not set — provide infrahub.address)" }}

--- a/charts/infrahub-mcp/templates/NOTES.txt
+++ b/charts/infrahub-mcp/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Infrahub MCP Server has been deployed.
+
+Get the MCP server URL by running:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "infrahub-mcp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.targetPort }}
+
+Then connect your MCP client to:
+  http://localhost:{{ .Values.service.port }}/mcp
+
+Configuration:
+  Auth mode:  {{ .Values.mcp.authMode }}
+  Read-only:  {{ .Values.mcp.readOnly }}
+  Infrahub:   {{ .Values.infrahub.address | default "auto-configured via sub-chart" }}

--- a/charts/infrahub-mcp/templates/_helpers.tpl
+++ b/charts/infrahub-mcp/templates/_helpers.tpl
@@ -68,3 +68,25 @@ Return the image name
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
+
+{{/*
+Name for the HTTPRoute resource
+*/}}
+{{- define "infrahub-mcp.httproute.name" -}}
+{{- if .Values.gatewayApi.httpRoute.name -}}
+  {{- .Values.gatewayApi.httpRoute.name -}}
+{{- else -}}
+  {{- printf "%s-httproute" (include "infrahub-mcp.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name for the Gateway resource
+*/}}
+{{- define "infrahub-mcp.gateway.name" -}}
+{{- if .Values.gatewayApi.gateway.name -}}
+  {{- .Values.gatewayApi.gateway.name -}}
+{{- else -}}
+  {{- printf "%s-gateway" (include "infrahub-mcp.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/infrahub-mcp/templates/_helpers.tpl
+++ b/charts/infrahub-mcp/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "infrahub-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "infrahub-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "infrahub-mcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "infrahub-mcp.labels" -}}
+helm.sh/chart: {{ include "infrahub-mcp.chart" . }}
+{{ include "infrahub-mcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "infrahub-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "infrahub-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "infrahub-mcp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "infrahub-mcp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "infrahub-mcp.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}

--- a/charts/infrahub-mcp/templates/deployment.yaml
+++ b/charts/infrahub-mcp/templates/deployment.yaml
@@ -47,15 +47,15 @@ spec:
             - name: INFRAHUB_ADDRESS
               value: {{ .Values.infrahub.address | quote }}
             {{- end }}
-            {{- if .Values.infrahub.existingSecret }}
+            {{- if .Values.infrahub.apiToken.existingSecret }}
             - name: INFRAHUB_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.infrahub.existingSecret }}
-                  key: {{ .Values.infrahub.existingSecretKey }}
-            {{- else if .Values.infrahub.apiToken }}
+                  name: {{ .Values.infrahub.apiToken.existingSecret }}
+                  key: {{ .Values.infrahub.apiToken.existingSecretKey }}
+            {{- else if .Values.infrahub.apiToken.value }}
             - name: INFRAHUB_API_TOKEN
-              value: {{ .Values.infrahub.apiToken | quote }}
+              value: {{ .Values.infrahub.apiToken.value | quote }}
             {{- end }}
             - name: INFRAHUB_MCP_AUTH_MODE
               value: {{ .Values.mcp.authMode | quote }}

--- a/charts/infrahub-mcp/templates/deployment.yaml
+++ b/charts/infrahub-mcp/templates/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "infrahub-mcp.fullname" . }}
+  labels:
+    {{- include "infrahub-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "infrahub-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "infrahub-mcp.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "infrahub-mcp.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: infrahub-mcp
+          image: {{ include "infrahub-mcp.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- if .Values.infrahub.address }}
+            - name: INFRAHUB_ADDRESS
+              value: {{ .Values.infrahub.address | quote }}
+            {{- end }}
+            {{- if .Values.infrahub.existingSecret }}
+            - name: INFRAHUB_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.infrahub.existingSecret }}
+                  key: {{ .Values.infrahub.existingSecretKey }}
+            {{- else if .Values.infrahub.apiToken }}
+            - name: INFRAHUB_API_TOKEN
+              value: {{ .Values.infrahub.apiToken | quote }}
+            {{- end }}
+            - name: INFRAHUB_MCP_AUTH_MODE
+              value: {{ .Values.mcp.authMode | quote }}
+            - name: INFRAHUB_MCP_READ_ONLY
+              value: {{ .Values.mcp.readOnly | quote }}
+            - name: INFRAHUB_MCP_LOG_LEVEL
+              value: {{ .Values.mcp.logLevel | quote }}
+            - name: INFRAHUB_MCP_BRANCH_PATTERN
+              value: {{ .Values.mcp.branching.pattern | quote }}
+            - name: INFRAHUB_MCP_MAX_BRANCH_RETRIES
+              value: {{ .Values.mcp.branching.maxRetries | quote }}
+            - name: INFRAHUB_MCP_CACHE_ENABLED
+              value: {{ .Values.mcp.cache.enabled | quote }}
+            - name: INFRAHUB_MCP_CACHE_LIST_TTL
+              value: {{ .Values.mcp.cache.listTtl | quote }}
+            - name: INFRAHUB_MCP_CACHE_READ_TTL
+              value: {{ .Values.mcp.cache.readTtl | quote }}
+            - name: INFRAHUB_MCP_RATE_LIMIT_RPS
+              value: {{ .Values.mcp.rateLimit.rps | quote }}
+            - name: INFRAHUB_MCP_RATE_LIMIT_BURST
+              value: {{ .Values.mcp.rateLimit.burst | quote }}
+            - name: INFRAHUB_MCP_RETRY_MAX_ATTEMPTS
+              value: {{ .Values.mcp.retry.maxAttempts | quote }}
+            - name: INFRAHUB_MCP_RETRY_BASE_DELAY
+              value: {{ .Values.mcp.retry.baseDelay | quote }}
+            - name: INFRAHUB_MCP_PROMETHEUS_ENABLED
+              value: {{ .Values.mcp.observability.prometheusEnabled | quote }}
+            - name: INFRAHUB_MCP_OTEL_ENABLED
+              value: {{ .Values.mcp.observability.otelEnabled | quote }}
+            - name: INFRAHUB_MCP_PING_INTERVAL_MS
+              value: {{ .Values.mcp.observability.pingIntervalMs | quote }}
+            - name: INFRAHUB_MCP_DEREFERENCE_SCHEMAS
+              value: {{ .Values.mcp.dereferenceSchemas | quote }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.envFromExistingSecrets }}
+          envFrom:
+            {{- range .Values.envFromExistingSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/infrahub-mcp/templates/gateway.yaml
+++ b/charts/infrahub-mcp/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.gatewayApi.enabled .Values.gatewayApi.gateway.enabled }}
+{{- if not .Values.gatewayApi.gateway.className }}
+  {{- fail "gatewayApi.gateway.className is required when gateway.enabled is true." }}
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "infrahub-mcp.gateway.name" . }}
+  labels:
+    {{- include "infrahub-mcp.labels" . | nindent 4 }}
+    {{- with .Values.gatewayApi.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayApi.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gatewayApi.gateway.className | quote }}
+  {{- with .Values.gatewayApi.gateway.listeners }}
+  listeners:
+  {{- range . }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: {{ .protocol }}
+      {{- with .hostname }}
+      hostname: {{ . | quote }}
+      {{- end }}
+      {{- with .tls }}
+      tls:
+        mode: {{ .mode | default "Terminate" }}
+        {{- with .certificateRefs }}
+        certificateRefs:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/infrahub-mcp/templates/httproute.yaml
+++ b/charts/infrahub-mcp/templates/httproute.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.gatewayApi.enabled }}
+{{- if .Values.ingress.enabled }}
+  {{- fail "gatewayApi and ingress are mutually exclusive. Please disable one of them." }}
+{{- end }}
+{{- if and (not .Values.gatewayApi.httpRoute.parentRefs) (not .Values.gatewayApi.gateway.enabled) }}
+  {{- fail "When gatewayApi is enabled, either httpRoute.parentRefs must be configured or gateway.enabled must be true." }}
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "infrahub-mcp.httproute.name" . }}
+  labels:
+    {{- include "infrahub-mcp.labels" . | nindent 4 }}
+    {{- with .Values.gatewayApi.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayApi.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- if .Values.gatewayApi.httpRoute.parentRefs }}
+  {{- range .Values.gatewayApi.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+  {{- end }}
+  {{- else }}
+    - name: {{ include "infrahub-mcp.gateway.name" . }}
+  {{- end }}
+  {{- with .Values.gatewayApi.httpRoute.hostnames }}
+  hostnames:
+  {{- range . }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.gatewayApi.httpRoute.path | default "/mcp" }}
+      backendRefs:
+        - name: {{ include "infrahub-mcp.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- with .Values.gatewayApi.httpRoute.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/infrahub-mcp/templates/ingress.yaml
+++ b/charts/infrahub-mcp/templates/ingress.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.gatewayApi.enabled }}
+  {{- fail "ingress and gatewayApi are mutually exclusive. Please disable one of them." }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "infrahub-mcp.fullname" . }}
+  labels:
+    {{- include "infrahub-mcp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "infrahub-mcp.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .hostname | quote }}
+      http:
+        paths:
+          - path: {{ default $.Values.ingress.path .path }}
+            pathType: {{ default $.Values.ingress.pathType .pathType }}
+            backend:
+              service:
+                name: {{ include "infrahub-mcp.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      {{- range .Values.ingress.extraHosts }}
+        {{- if .hostname }}
+        - {{ .hostname }}
+        {{- end }}
+      {{- end }}
+      secretName: {{ include "infrahub-mcp.fullname" . }}-tls
+    {{- end }}
+    {{- with .Values.ingress.extraTls }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/infrahub-mcp/templates/service.yaml
+++ b/charts/infrahub-mcp/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "infrahub-mcp.fullname" . }}
+  labels:
+    {{- include "infrahub-mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "infrahub-mcp.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/infrahub-mcp/templates/serviceaccount.yaml
+++ b/charts/infrahub-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "infrahub-mcp.serviceAccountName" . }}
+  labels:
+    {{- include "infrahub-mcp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/infrahub-mcp/values.yaml
+++ b/charts/infrahub-mcp/values.yaml
@@ -1,0 +1,162 @@
+# Default values for infrahub-mcp
+
+# -- Number of replicas
+replicaCount: 1
+
+# -- Container image configuration
+image:
+  repository: registry.opsmill.io/opsmill/infrahub-mcp
+  # -- Tag defaults to chart appVersion if not specified
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full name
+fullnameOverride: ""
+
+# -- ServiceAccount configuration
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- Name of the ServiceAccount (auto-generated if empty)
+  name: ""
+  # -- Annotations to add to the ServiceAccount
+  annotations: {}
+
+# -- Infrahub connection settings
+infrahub:
+  # -- Infrahub server address (auto-configured when used as sub-chart)
+  address: ""
+  # -- API token for authenticating with Infrahub
+  apiToken: ""
+  # -- Name of an existing Secret containing INFRAHUB_API_TOKEN
+  existingSecret: ""
+  # -- Key within the existing Secret that holds the API token
+  existingSecretKey: "INFRAHUB_API_TOKEN"
+
+# -- MCP server configuration
+mcp:
+  # -- Authentication mode: "none", "token-passthrough", "basic-passthrough", "oidc"
+  authMode: "none"
+  # -- Enable read-only mode (blocks all write operations)
+  readOnly: false
+  # -- Log level: "debug", "info", "warning", "error"
+  logLevel: "info"
+
+  # -- Branching configuration
+  branching:
+    # -- Branch name pattern for auto-created branches
+    pattern: "mcp/session-{date}-{hex}"
+    # -- Max retries for branch creation on name collision
+    maxRetries: 5
+
+  # -- Caching configuration
+  cache:
+    # -- Enable response caching
+    enabled: false
+    # -- TTL in seconds for list operations
+    listTtl: 300
+    # -- TTL in seconds for read operations
+    readTtl: 3600
+
+  # -- Rate limiting configuration
+  rateLimit:
+    # -- Requests per second (0 = disabled)
+    rps: 0
+    # -- Burst allowance (0 = disabled)
+    burst: 0
+
+  # -- Retry configuration
+  retry:
+    # -- Max retry attempts (0 = disabled)
+    maxAttempts: 0
+    # -- Base delay between retries in seconds
+    baseDelay: 1
+
+  # -- Observability configuration
+  observability:
+    # -- Enable Prometheus metrics endpoint
+    prometheusEnabled: false
+    # -- Enable OpenTelemetry tracing
+    otelEnabled: false
+    # -- Ping keepalive interval in milliseconds (0 = disabled)
+    pingIntervalMs: 0
+
+  # -- Enable JSON $ref dereferencing in schemas
+  dereferenceSchemas: false
+
+# -- Additional environment variables (key: value pairs)
+extraEnv: {}
+
+# -- Name of existing Secret(s) to load as environment variables
+envFromExistingSecrets: []
+
+# -- Service configuration
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 8001
+  # -- Container target port
+  targetPort: 8001
+
+# -- Resource limits and requests
+resources: {}
+#  requests:
+#    cpu: "100m"
+#    memory: "128Mi"
+#  limits:
+#    cpu: "500m"
+#    memory: "256Mi"
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# -- Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3

--- a/charts/infrahub-mcp/values.yaml
+++ b/charts/infrahub-mcp/values.yaml
@@ -29,14 +29,18 @@ serviceAccount:
 
 # -- Infrahub connection settings
 infrahub:
-  # -- Infrahub server address (auto-configured when used as sub-chart)
+  # -- Infrahub server address (e.g. "http://infrahub-infrahub-server:8000")
   address: ""
   # -- API token for authenticating with Infrahub
-  apiToken: ""
-  # -- Name of an existing Secret containing INFRAHUB_API_TOKEN
-  existingSecret: ""
-  # -- Key within the existing Secret that holds the API token
-  existingSecretKey: "INFRAHUB_API_TOKEN"
+  apiToken:
+    # -- API token value, rendered as a plain-text env var. Prefer
+    # `existingSecret` for production deployments.
+    value: ""
+    # -- Name of an existing Secret containing the API token. Takes precedence
+    # over `value` when set.
+    existingSecret: ""
+    # -- Key within the existing Secret that holds the API token
+    existingSecretKey: "INFRAHUB_API_TOKEN"
 
 # -- MCP server configuration
 mcp:
@@ -103,6 +107,77 @@ service:
   port: 8001
   # -- Container target port
   targetPort: 8001
+
+# -- Ingress configuration for exposing the MCP server externally.
+# To serve the MCP server on the same host as Infrahub (e.g. under a "/mcp"
+# path prefix), set `hostname` to the Infrahub server's ingress hostname and
+# keep the default `path`.
+ingress:
+  # -- Whether to enable Ingress for the MCP server
+  enabled: false
+  # -- IngressClass name to use
+  ingressClassName: ""
+  # -- Hostname to configure for the ingress
+  hostname: ""
+  # -- Path prefix under which the MCP server is exposed
+  path: /mcp
+  # -- PathType for the ingress rule
+  pathType: Prefix
+  # -- Annotations to configure on the ingress
+  annotations: {}
+  # -- Additional hosts to expose (each entry: hostname, path, pathType)
+  extraHosts: []
+  # -- Enable TLS for `hostname` using the secret "<fullname>-tls"
+  tls: false
+  # -- Additional TLS configuration entries (raw `tls` list items)
+  extraTls: []
+
+# -- Gateway API configuration for the MCP server.
+# ref: https://gateway-api.sigs.k8s.io/
+# Mutually exclusive with `ingress`.
+gatewayApi:
+  # -- Whether to enable Gateway API HTTPRoute for the MCP server
+  enabled: false
+  httpRoute:
+    # -- HTTPRoute resource name (defaults to "<fullname>-httproute")
+    name: ""
+    # -- Additional labels for the HTTPRoute resource
+    labels: {}
+    # -- Additional annotations for the HTTPRoute resource
+    annotations: {}
+    # -- Hostnames that this HTTPRoute should match
+    hostnames: []
+    # -- Parent Gateway references
+    parentRefs: []
+    # - name: default-gateway
+    #   namespace: net
+    #   sectionName: https-listener
+    # -- Path prefix for the default matching rule
+    path: /mcp
+    # -- Additional HTTPRoute rules beyond the auto-generated one
+    extraRules: []
+  gateway:
+    # -- Whether to create a Gateway resource (most users will reference an existing Gateway via httpRoute.parentRefs)
+    enabled: false
+    # -- GatewayClass name (required when gateway.enabled is true)
+    className: ""
+    # -- Gateway resource name (defaults to "<fullname>-gateway")
+    name: ""
+    # -- Additional labels for the Gateway resource
+    labels: {}
+    # -- Additional annotations for the Gateway resource
+    annotations: {}
+    # -- Gateway listeners configuration
+    listeners: []
+    # - name: https
+    #   port: 443
+    #   protocol: HTTPS
+    #   hostname: ""
+    #   tls:
+    #     mode: Terminate
+    #     certificateRefs:
+    #       - kind: Secret
+    #         name: my-tls-cert
 
 # -- Resource limits and requests
 resources: {}

--- a/charts/infrahub/Chart.yaml
+++ b/charts/infrahub/Chart.yaml
@@ -58,3 +58,7 @@ dependencies:
     version: "0.1.0"
     repository: "oci://registry.opsmill.io/opsmill/chart"
     condition: infrahub-observability.enabled
+  - name: infrahub-mcp
+    version: "0.1.0"
+    repository: "oci://registry.opsmill.io/opsmill/chart"
+    condition: infrahub-mcp.enabled

--- a/charts/infrahub/Chart.yaml
+++ b/charts/infrahub/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.23.0
+version: 4.24.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/infrahub/README.md
+++ b/charts/infrahub/README.md
@@ -62,6 +62,7 @@ The chart offers the ability to configure persistence for the database and other
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.4.1 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 19.5.2 |
 | oci://registry.opsmill.io/opsmill/chart | infrahub-backup | 1.2.0 |
+| oci://registry.opsmill.io/opsmill/chart | infrahub-mcp | 0.1.0 |
 | oci://registry.opsmill.io/opsmill/chart | infrahub-observability | 0.1.0 |
 
 ## Values
@@ -101,6 +102,9 @@ The chart offers the ability to configure persistence for the database and other
 | infrahub-backup.backup | object | `{"enabled":false,"mode":"cronjob","schedule":"0 2 * * *","storage":{"s3":{"bucket":"","endpoint":"","prefix":"","region":"us-east-1","secretName":""},"type":"s3"}}` | Backup configuration |
 | infrahub-backup.enabled | bool | `false` | Whether to enable Infrahub Backup |
 | infrahub-backup.restore | object | `{"enabled":false,"s3":{"bucket":"","endpoint":"","key":"","region":"us-east-1","secretName":""}}` | Restore configuration |
+| infrahub-mcp.enabled | bool | `false` | Whether to enable Infrahub MCP Server |
+| infrahub-mcp.infrahub | object | `{"address":"","apiToken":{"value":""}}` | Infrahub connection for the MCP server. Set `address` to the in-cluster Infrahub URL (e.g. "http://<release>-infrahub-server:8000") and provide an API token via `apiToken.value` or `apiToken.existingSecret`. |
+| infrahub-mcp.mcp | object | `{"authMode":"none","logLevel":"info","readOnly":false}` | MCP server settings |
 | infrahub-observability.enabled | bool | `false` | Deploy the infrahub-observability subchart and force tracing on. |
 | infrahubDemoData.affinity | object | `{}` | Affinity for the demo data job pod |
 | infrahubDemoData.backoffLimit | int | `4` | Backoff limit for the Kubernetes job that will load the data |

--- a/charts/infrahub/values.yaml
+++ b/charts/infrahub/values.yaml
@@ -490,3 +490,19 @@ infrahub-backup:
 infrahub-observability:
   # -- Deploy the infrahub-observability subchart and force tracing on.
   enabled: false
+
+# -------------- Infrahub MCP Server ---------------
+infrahub-mcp:
+  # -- Whether to enable Infrahub MCP Server
+  enabled: false
+
+  # -- Infrahub connection (auto-configured from parent chart)
+  infrahub:
+    address: ""
+    apiToken: ""
+
+  # -- MCP server settings
+  mcp:
+    authMode: "none"
+    readOnly: false
+    logLevel: "info"

--- a/charts/infrahub/values.yaml
+++ b/charts/infrahub/values.yaml
@@ -492,14 +492,21 @@ infrahub-observability:
   enabled: false
 
 # -------------- Infrahub MCP Server ---------------
+# Optional MCP server for Infrahub, disabled by default. The Infrahub
+# connection is not wired automatically: set `infrahub.address` to the
+# in-cluster server URL and provide an API token. See
+# charts/infrahub-mcp/values.yaml for the full set of options.
 infrahub-mcp:
   # -- Whether to enable Infrahub MCP Server
   enabled: false
 
-  # -- Infrahub connection (auto-configured from parent chart)
+  # -- Infrahub connection for the MCP server. Set `address` to the in-cluster
+  # Infrahub URL (e.g. "http://<release>-infrahub-server:8000") and provide an
+  # API token via `apiToken.value` or `apiToken.existingSecret`.
   infrahub:
     address: ""
-    apiToken: ""
+    apiToken:
+      value: ""
 
   # -- MCP server settings
   mcp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyyaml>=6.0",
     "infrahub-sdk[all]>=1.0",
     "boto3>=1.35",
+    "mcp>=1.9",
 ]
 
 [tool.uv]
@@ -29,4 +30,5 @@ markers = [
     "enterprise: tests for the infrahub-enterprise chart",
     "backup: tests for the infrahub-backup chart",
     "observability: tests for the infrahub-observability chart",
+    "mcp: tests for the infrahub-mcp chart",
 ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,8 +6,10 @@ from the local `charts/` directory (not from the OCI registry) so the test
 reflects the working-tree changes.
 """
 
+import asyncio
 import shutil
 import subprocess
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
@@ -32,6 +34,7 @@ LOCAL_CHART_NAMES = {
     "infrahub-enterprise",
     "infrahub-backup",
     "infrahub-observability",
+    "infrahub-mcp",
 }
 
 
@@ -72,6 +75,37 @@ def helm_install(
     for key, value in (sets or {}).items():
         cmd.extend(["--set", f"{key}={value}"])
     subprocess.run(cmd, check=True)
+
+
+def install_traefik(
+    *,
+    namespace: str,
+    kubeconfig: str,
+    release: str = "traefik",
+    version: str = "40.2.0",
+) -> None:
+    """Install Traefik as the ingress controller and wait for it.
+
+    Traefik watches Ingress resources inside the vcluster and routes by Host
+    header. Its Service is type LoadBalancer: vcluster ships an embedded load
+    balancer that assigns it a node address reachable from the test runner, so
+    tests hit the ``web`` entrypoint (port 80) directly with the Infrahub
+    hostname — no port-forward needed. The chart registers a default
+    IngressClass named after the release ("traefik").
+    """
+    subprocess.run(
+        [
+            "helm", "upgrade", "--install", release, "traefik",
+            "--repo", "https://traefik.github.io/charts",
+            "--version", version,
+            "--create-namespace", "-n", namespace,
+            "--kubeconfig", kubeconfig,
+            "--set", "service.type=LoadBalancer",
+            "--set", "deployment.replicas=1",
+            "--wait", "--timeout", "5m",
+        ],
+        check=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +212,38 @@ async def portforward_service(
         yield url
 
 
+async def loadbalancer_url(
+    kubeconfig: str,
+    namespace: str,
+    name: str,
+    *,
+    port: int = 80,
+    timeout: float = 180.0,
+) -> str:
+    """Return the base URL of a LoadBalancer Service once it has an address.
+
+    vcluster's embedded load balancer assigns the Service a node address that
+    is reachable from the test runner, so the caller can hit it directly (with
+    a Host header for name-based routing) instead of port-forwarding.
+    """
+    api = await kr8s.asyncio.api(kubeconfig=kubeconfig)
+    service = await AsyncService.get(name, namespace=namespace, api=api)
+    start = time.time()
+    while time.time() - start < timeout:
+        await service.refresh()
+        ingress = (
+            service.raw.get("status", {}).get("loadBalancer", {}) or {}
+        ).get("ingress") or []
+        for entry in ingress:
+            address = entry.get("ip") or entry.get("hostname")
+            if address:
+                return f"http://{address}:{port}"
+        await asyncio.sleep(3)
+    raise AssertionError(
+        f"Service '{name}' in '{namespace}' got no LoadBalancer address after {timeout}s"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixture: infrahub_k8s (community chart)
 # ---------------------------------------------------------------------------
@@ -209,6 +275,62 @@ async def infrahub_k8s(
         "kubeconfig_path": kubeconfig,
         "token": INFRAHUB_ADMIN_TOKEN,
         "server_label": "service=infrahub-server",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixture: infrahub_mcp_k8s (infrahub + the infrahub-mcp sub-chart)
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+async def infrahub_mcp_k8s(
+    vcluster: dict, staged_charts, request
+) -> AsyncGenerator[dict, None]:
+    """Deploy Infrahub with the infrahub-mcp sub-chart enabled, behind a shared
+    ingress.
+
+    Traefik is installed into the namespace as the ingress controller, then
+    Infrahub is deployed with the MCP sub-chart on. Both the Infrahub server
+    (path "/") and the MCP
+    server (path "/mcp") publish Ingress objects for the same host, so the
+    controller serves them as a single virtual host — the MCP server is reached
+    under "/mcp" on the very host that serves Infrahub. The MCP server is wired
+    to the in-cluster Infrahub API with the admin token.
+    """
+    kubeconfig = vcluster["kubeconfig_path"]
+    namespace = "infrahub-mcp"
+    hostname = "infrahub-cluster.local"
+    _register_namespace(request, namespace)
+
+    install_traefik(namespace=namespace, kubeconfig=kubeconfig)
+
+    helm_install(
+        release="infrahub",
+        chart_path=staged_charts["infrahub"],
+        namespace=namespace,
+        kubeconfig=kubeconfig,
+        values_files=[FIXTURES_DIR / "infrahub-values.yaml"],
+        sets={
+            "infrahubServer.ingress.enabled": "true",
+            "infrahubServer.ingress.hostname": hostname,
+            "infrahubServer.ingress.ingressClassName": "traefik",
+            "infrahub-mcp.enabled": "true",
+            "infrahub-mcp.image.pullPolicy": "IfNotPresent",
+            "infrahub-mcp.infrahub.address": "http://infrahub-infrahub-server:8000",
+            "infrahub-mcp.infrahub.apiToken.value": INFRAHUB_ADMIN_TOKEN,
+            "infrahub-mcp.ingress.enabled": "true",
+            "infrahub-mcp.ingress.hostname": hostname,
+            "infrahub-mcp.ingress.ingressClassName": "traefik",
+            "infrahub-mcp.ingress.path": "/mcp",
+        },
+    )
+
+    # helm --wait already gated on the server and MCP deployments being ready;
+    # the test reaches both through the Traefik ingress (no port-forward).
+    yield {
+        "namespace": namespace,
+        "kubeconfig_path": kubeconfig,
+        "ingress_hostname": hostname,
+        "ingress_service": "traefik",
     }
 
 

--- a/tests/e2e/test_infrahub_mcp.py
+++ b/tests/e2e/test_infrahub_mcp.py
@@ -1,0 +1,78 @@
+"""E2E: deploy the infrahub-mcp sub-chart against a running Infrahub and verify
+the MCP server is exposed under "/mcp" on the same ingress host that serves
+Infrahub, and that its tools work end to end through that ingress.
+"""
+
+import re
+import uuid
+
+import pytest
+
+from tests.e2e.conftest import loadbalancer_url
+from tests.helpers.utils import mcp_result_text, mcp_session, wait_for_http
+
+pytestmark = [pytest.mark.e2e, pytest.mark.k8s, pytest.mark.mcp]
+
+
+async def test_mcp_tools_work_via_shared_ingress(infrahub_mcp_k8s):
+    """The MCP server is reachable under "/mcp" on the Infrahub ingress host and
+    its tools round-trip to Infrahub.
+
+    Everything is driven through the shared Traefik ingress (no port-forward):
+    Infrahub answers at "/", and on the same host the MCP server answers under
+    "/mcp", where a tag created via the write tool is read back via the query
+    tool — exercising the full MCP -> Infrahub round-trip.
+    """
+    kubeconfig = infrahub_mcp_k8s["kubeconfig_path"]
+    namespace = infrahub_mcp_k8s["namespace"]
+    host = infrahub_mcp_k8s["ingress_hostname"]
+    headers = {"Host": host}
+
+    # The ingress controller is exposed via vcluster's embedded load balancer.
+    base = await loadbalancer_url(
+        kubeconfig, namespace, infrahub_mcp_k8s["ingress_service"], port=80
+    )
+
+    # Infrahub is reachable at "/" on this host (proves the controller routes
+    # and the shared host resolves to the Infrahub server).
+    await wait_for_http(
+        f"{base}/api/config", headers=headers, timeout=180.0, interval=5.0
+    )
+
+    tag_name = f"mcp-e2e-{uuid.uuid4().hex[:8]}"
+
+    # The MCP server answers under "/mcp" on the SAME host. A completed MCP
+    # session (initialize) means the request reached the MCP server — an ingress
+    # mismatch would hit the default backend and the handshake would fail.
+    async with mcp_session(f"{base}/mcp", headers=headers) as session:
+        # Tool catalog is built from the connected Infrahub's schema.
+        catalog = {tool.name for tool in (await session.list_tools()).tools}
+        assert {"node_upsert", "get_session_info", "get_nodes"} <= catalog, catalog
+
+        # Create a tag via the write tool (lands on an auto-created session branch).
+        created = await session.call_tool(
+            "node_upsert", {"kind": "BuiltinTag", "data": {"name": tag_name}}
+        )
+        assert not created.isError, mcp_result_text(created)
+
+        # Find the session branch the write landed on.
+        info = mcp_result_text(await session.call_tool("get_session_info", {}))
+        match = re.search(r"mcp/session-[\w.-]+", info)
+        assert match, f"no session branch reported by get_session_info: {info}"
+        branch = match.group(0)
+
+        # Read the tag back via the query tool on that branch.
+        found = await session.call_tool(
+            "get_nodes",
+            {
+                "kind": "BuiltinTag",
+                "branch": branch,
+                "filters": {"name__value": tag_name},
+                "include_attributes": True,
+            },
+        )
+        assert not found.isError, mcp_result_text(found)
+        assert tag_name in mcp_result_text(found), (
+            f"MCP get_nodes did not return seeded tag {tag_name!r}: "
+            f"{mcp_result_text(found)}"
+        )

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import time
 import uuid
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import httpx
@@ -24,13 +25,18 @@ async def wait_for_http(
     interval: float = 2.0,
     expected_status: int = 200,
     auth: tuple[str, str] | None = None,
+    headers: dict | None = None,
 ) -> None:
-    """Poll an HTTP endpoint until it returns the expected status code."""
+    """Poll an HTTP endpoint until it returns the expected status code.
+
+    ``headers`` lets callers send e.g. a ``Host`` header so a request through a
+    port-forwarded ingress controller is routed to the right virtual host.
+    """
     start = time.time()
     async with httpx.AsyncClient() as client:
         while time.time() - start < timeout:
             try:
-                resp = await client.get(url, timeout=5, auth=auth)
+                resp = await client.get(url, timeout=5, auth=auth, headers=headers)
                 if resp.status_code == expected_status:
                     return
             except httpx.HTTPError:
@@ -111,6 +117,50 @@ async def modify_infrahub_data(url: str, token: str, data: dict) -> None:
     assert all(t.name.value != data["tag_name"] for t in tags), (
         f"Tag '{data['tag_name']}' still exists after deletion"
     )
+
+
+# ---------------------------------------------------------------------------
+# MCP client helpers (streamable-HTTP transport)
+# ---------------------------------------------------------------------------
+@asynccontextmanager
+async def mcp_session(
+    mcp_url: str, headers: dict | None = None, timeout: float = 120.0
+):
+    """Open an initialized MCP session over the streamable-HTTP transport.
+
+    ``headers`` may carry a ``Host`` header so the session is established
+    through a name-based ingress. Yields an initialized ``ClientSession`` so a
+    test can issue several tool calls on one session — e.g. a write tool then a
+    read tool that share the auto-created session branch.
+    """
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(mcp_url, headers=headers, timeout=timeout) as (
+        read,
+        write,
+        _,
+    ):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+def mcp_result_text(result) -> str:
+    """Serialize an MCP tool-call result to text (content blocks + structured).
+
+    Folding both forms in lets callers assert on the payload without depending
+    on whether a tool returns text content, structured output, or both.
+    """
+    parts = [
+        block.text
+        for block in result.content
+        if getattr(block, "text", None) is not None
+    ]
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None:
+        parts.append(json.dumps(structured, default=str))
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -661,6 +661,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "httpx-ws"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -694,6 +703,7 @@ dependencies = [
     { name = "infrahub-sdk", extra = ["all"] },
     { name = "kr8s" },
     { name = "kubernetes-asyncio" },
+    { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -706,6 +716,7 @@ requires-dist = [
     { name = "infrahub-sdk", extras = ["all"], specifier = ">=1.0" },
     { name = "kr8s", specifier = ">=0.20" },
     { name = "kubernetes-asyncio", specifier = ">=33.0" },
+    { name = "mcp", specifier = ">=1.9" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -780,6 +791,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -905,6 +943,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -1486,6 +1549,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1565,6 +1642,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1596,6 +1682,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
     { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -1654,6 +1762,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1664,6 +1786,143 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
 ]
 
 [[package]]
@@ -1694,6 +1953,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -1841,6 +2126,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a new `infrahub-mcp` Helm chart (`charts/infrahub-mcp/`) that deploys the [Infrahub MCP server](https://github.com/opsmill/infrahub-mcp) as a Kubernetes Deployment + Service
- Wires it into the main `infrahub` chart as an optional conditional dependency (`infrahub-mcp.enabled: false` by default), following the same pattern as `infrahub-backup`
- Full configuration surface covering all `INFRAHUB_MCP_*` env vars: auth modes (none/token-passthrough/basic-passthrough/oidc), read-only mode, caching, rate limiting, branching, observability (Prometheus/OpenTelemetry), and health probes

Related: https://github.com/opsmill/infrahub-mcp/pull/62

## Test plan

- [ ] `helm lint charts/infrahub-mcp/` passes
- [ ] `helm template test charts/infrahub-mcp/` renders Deployment, Service, ServiceAccount correctly
- [ ] Env vars render with `--set infrahub.address=... --set infrahub.apiToken=...`
- [ ] `existingSecret` flow renders `secretKeyRef` instead of plain-text token
- [ ] `mcp.readOnly=true` and `mcp.authMode=oidc` overrides render correctly
- [ ] Chart is disabled by default when used as sub-chart of `infrahub`
- [ ] Deploy to test cluster with `infrahub-mcp.enabled=true` and verify MCP server connects to Infrahub
