### PR TITLE
feat(infrahub-enterprise): tune prefect triggers read batch size

### DIFF
--- a/charts/infrahub-enterprise/values.large-data.yaml
+++ b/charts/infrahub-enterprise/values.large-data.yaml
@@ -84,3 +84,5 @@ infrahub:
           value: "20"
         - name: PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_BATCH_SIZE
           value: "20"
+        - name: PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE
+          value: "20"

--- a/charts/infrahub-enterprise/values.large.yaml
+++ b/charts/infrahub-enterprise/values.large.yaml
@@ -84,3 +84,5 @@ infrahub:
           value: "20"
         - name: PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_BATCH_SIZE
           value: "20"
+        - name: PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE
+          value: "20"

--- a/charts/infrahub-enterprise/values.medium-data.yaml
+++ b/charts/infrahub-enterprise/values.medium-data.yaml
@@ -84,3 +84,5 @@ infrahub:
           value: "10"
         - name: PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_BATCH_SIZE
           value: "10"
+        - name: PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE
+          value: "10"

--- a/charts/infrahub-enterprise/values.medium.yaml
+++ b/charts/infrahub-enterprise/values.medium.yaml
@@ -84,3 +84,5 @@ infrahub:
           value: "10"
         - name: PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_BATCH_SIZE
           value: "10"
+        - name: PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE
+          value: "10"

--- a/charts/infrahub-enterprise/values.small.yaml
+++ b/charts/infrahub-enterprise/values.small.yaml
@@ -84,3 +84,5 @@ infrahub:
           value: "1"
         - name: PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_BATCH_SIZE
           value: "1"
+        - name: PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE
+          value: "1"


### PR DESCRIPTION
## Summary
- Add `PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE` to the `prefect-server.backgroundServices.env` block of each enterprise preset so the triggers service scales with deployment size instead of running at the Prefect default.
- Values mirror the existing `TASK_RUN_RECORDER_READ_BATCH_SIZE` scaling: small=1, medium/medium-data=10, large/large-data=20.

## Test plan
- [x] `helm template charts/infrahub-enterprise -f charts/infrahub-enterprise/values.<preset>.yaml` for each of small/medium/medium-data/large/large-data and confirm the new env var renders on the background-services Deployment with the expected value.
- [x] `yamllint` shows no new warnings/errors beyond the pre-existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)