### PR TITLE
feat(infrahub): wire serviceAccount configuration into pod specs

### DIFF
--- a/charts/infrahub-enterprise/Chart.yaml
+++ b/charts/infrahub-enterprise/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.6
+version: 4.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -27,5 +27,5 @@ appVersion: "1.9.6"
 
 dependencies:
   - name: infrahub
-    version: "4.21.6"
+    version: "4.22.0"
     repository: "oci://registry.opsmill.io/opsmill/chart"

--- a/charts/infrahub-enterprise/README.md
+++ b/charts/infrahub-enterprise/README.md
@@ -58,7 +58,7 @@ The chart offers the ability to configure persistence for the database and other
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.20.2 |
+| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.22.0 |
 
 ## Values
 
@@ -83,6 +83,7 @@ The chart offers the ability to configure persistence for the database and other
 | infrahub.infrahubServer.infrahubServer.env.INFRAHUB_DB_TYPE | string | `"neo4j"` |  |
 | infrahub.infrahubServer.infrahubServer.env.INFRAHUB_GIT_REPOSITORIES_DIRECTORY | string | `"/opt/infrahub/git"` |  |
 | infrahub.infrahubServer.infrahubServer.env.INFRAHUB_INITIAL_ADMIN_TOKEN | string | `"06438eb2-8019-4776-878c-0941b1f1d1ec"` |  |
+| infrahub.infrahubServer.infrahubServer.env.INFRAHUB_INITIAL_AGENT_TOKEN | string | `"44af444d-3b26-410d-9546-b758657e026c"` |  |
 | infrahub.infrahubServer.infrahubServer.env.INFRAHUB_LOG_LEVEL | string | `"INFO"` |  |
 | infrahub.infrahubServer.infrahubServer.env.INFRAHUB_PRODUCTION | string | `"false"` |  |
 | infrahub.infrahubServer.infrahubServer.env.INFRAHUB_SECURITY_SECRET_KEY | string | `"327f747f-efac-42be-9e73-999f08f86b92"` |  |

--- a/charts/infrahub-enterprise/templates/_helpers.tpl
+++ b/charts/infrahub-enterprise/templates/_helpers.tpl
@@ -49,14 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "infrahub-enterprise-helm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "infrahub-enterprise-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "infrahub-enterprise-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}

--- a/charts/infrahub/Chart.yaml
+++ b/charts/infrahub/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.21.6
+version: 4.22.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/infrahub/README.md
+++ b/charts/infrahub/README.md
@@ -197,7 +197,7 @@ The chart offers the ability to configure persistence for the database and other
 | neo4j.volumes.data.mode | string | `"volume"` |  |
 | neo4j.volumes.data.volume.emptyDir | object | `{}` |  |
 | prefect-server.enabled | bool | `true` |  |
-| prefect-server.global.prefect.image.prefectTag | string | `"1.8.4"` |  |
+| prefect-server.global.prefect.image.prefectTag | string | `"1.9.6"` |  |
 | prefect-server.global.prefect.image.repository | string | `"registry.opsmill.io/opsmill/infrahub"` |  |
 | prefect-server.postgresql.enabled | bool | `true` |  |
 | prefect-server.postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
@@ -237,6 +237,10 @@ The chart offers the ability to configure persistence for the database and other
 | redis.master.resourcesPreset | string | `"medium"` |  |
 | redis.master.service.ports.redis | int | `6379` |  |
 | redis.nameOverride | string | `"cache"` |  |
+| serviceAccount | object | `{"annotations":{},"create":false,"name":""}` | ServiceAccount configuration for the Infrahub pods |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
+| serviceAccount.create | bool | `false` | Create a ServiceAccount for the Infrahub pods |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount to use (auto-generated if empty and create is true; if empty and create is false, the field is omitted from pod specs) |
 | upgrade.enabled | bool | `false` | Whether to run infrahub upgrade as a post-install/pre-upgrade hook job |
 
 ----------------------------------------------

--- a/charts/infrahub/templates/_helpers.tpl
+++ b/charts/infrahub/templates/_helpers.tpl
@@ -66,13 +66,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use.
+Returns an empty string when no ServiceAccount is created nor named, so that
+the serviceAccountName field can be omitted from pod specs.
 */}}
 {{- define "infrahub-helm.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "infrahub-helm.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/charts/infrahub/templates/emma.yaml
+++ b/charts/infrahub/templates/emma.yaml
@@ -22,6 +22,9 @@ spec:
         service: emma
       {{- include "infrahub-helm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with include "infrahub-helm.serviceAccountName" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/infrahub/templates/infrahub-demo-data-job.yaml
+++ b/charts/infrahub/templates/infrahub-demo-data-job.yaml
@@ -13,6 +13,9 @@ spec:
   backoffLimit: {{ .Values.infrahubDemoData.backoffLimit }}
   template:
     spec:
+      {{- with include "infrahub-helm.serviceAccountName" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/infrahub/templates/infrahub-server.yaml
+++ b/charts/infrahub/templates/infrahub-server.yaml
@@ -31,6 +31,9 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with include "infrahub-helm.serviceAccountName" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/infrahub/templates/infrahub-task-worker.yaml
+++ b/charts/infrahub/templates/infrahub-task-worker.yaml
@@ -31,6 +31,9 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with include "infrahub-helm.serviceAccountName" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/infrahub/templates/infrahub-upgrade-job.yaml
+++ b/charts/infrahub/templates/infrahub-upgrade-job.yaml
@@ -20,6 +20,9 @@ spec:
         service: infrahub-upgrade
       {{- include "infrahub-helm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with include "infrahub-helm.serviceAccountName" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/infrahub/templates/serviceaccount.yaml
+++ b/charts/infrahub/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "infrahub-helm.serviceAccountName" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+  {{- include "infrahub-helm.labels" . | nindent 4 }}
+  annotations:
+  {{- include "infrahub-helm.annotations" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/infrahub/values.yaml
+++ b/charts/infrahub/values.yaml
@@ -15,6 +15,15 @@ global:
   # -- Labels to use for all configured pods
   podLabels: {}
 
+# -- ServiceAccount configuration for the Infrahub pods
+serviceAccount:
+  # -- Create a ServiceAccount for the Infrahub pods
+  create: false
+  # -- Name of the ServiceAccount to use (auto-generated if empty and create is true; if empty and create is false, the field is omitted from pod specs)
+  name: ""
+  # -- Annotations to add to the ServiceAccount
+  annotations: {}
+
 # ----------- Cache -----------
 # Resource presets: nano, micro, small, medium, large, xlarge, 2xlarge
 # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl


### PR DESCRIPTION
## Summary

The `infrahub-helm.serviceAccountName` helper existed in the `infrahub` chart but was completely orphaned: no top-level `serviceAccount` block in values, no `ServiceAccount` template, and no pod spec referencing it — so configuring a service account name silently did nothing.

### infrahub (4.21.6 → 4.22.0)

- Add top-level `serviceAccount` values block (`create`, `name`, `annotations`), mirroring the already-wired `infrahub-backup` chart
- Add `templates/serviceaccount.yaml`, rendered when `serviceAccount.create=true` (supports annotations, e.g. for IRSA/Workload Identity)
- Wire `serviceAccountName` into all 5 pod specs (server, task-worker, upgrade job, demo-data job, emma) via `with`, so the field is omitted when unset — default installs render byte-identical to before (no rollout on upgrade)
- Regenerated README (also picks up stale `prefectTag` doc entry)

### infrahub-enterprise (4.7.6 → 4.8.0)

- Remove the orphaned `infrahub-enterprise-helm.serviceAccountName` helper (dead code — workloads come from the `infrahub` dependency)
- Bump `infrahub` dependency pin to 4.22.0
- Regenerated README

## Behavior

| Configuration | Result |
|---|---|
| defaults | no `serviceAccountName` rendered (unchanged manifests) |
| `serviceAccount.create=true` | `ServiceAccount` created, all 5 pods reference it |
| `serviceAccount.name=my-sa`, `create=false` | pods reference the existing SA, none created |

## Test plan

- [x] `helm lint` passes for both charts
- [x] `helm template` verified for the three configurations above

🤖 Generated with [Claude Code](https://claude.com/claude-code)