### PR TITLE
ci: bump JS actions to Node 24 versions

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -12,10 +12,10 @@ runs:
       uses: "loft-sh/setup-vcluster@68e17a8c3618e3c47d635842b803d4f560f694e8"
 
     - name: "Set up Helm"
-      uses: "azure/setup-helm@v4.3.0"
+      uses: "azure/setup-helm@v5.0.0"
 
     - name: "Set up kubectl"
-      uses: "azure/setup-kubectl@v4"
+      uses: "azure/setup-kubectl@v5"
 
     - name: "Set up Python"
       uses: "actions/setup-python@v6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       mcp: ${{ steps.filter.outputs.mcp }}
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
       - id: filter
-        uses: "dorny/paths-filter@v3"
+        uses: "dorny/paths-filter@v4"
         with:
           filters: |
             infrahub:
@@ -52,10 +52,10 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
-      - uses: "azure/setup-helm@v4.3.0"
+      - uses: "azure/setup-helm@v5.0.0"
       - name: "Updating dependencies"
         run: "helm dependency update charts/infrahub"
       - name: "Linting: helm lint infrahub"
@@ -67,10 +67,10 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
-      - uses: "azure/setup-helm@v4.3.0"
+      - uses: "azure/setup-helm@v5.0.0"
       - name: "Linting: helm lint infrahub-enterprise"
         run: "helm lint charts/infrahub-enterprise"
 
@@ -80,10 +80,10 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
-      - uses: "azure/setup-helm@v4.3.0"
+      - uses: "azure/setup-helm@v5.0.0"
       - name: "Updating dependencies: infrahub-observability"
         run: "helm dependency update charts/infrahub-observability"
       - name: "Linting: helm lint infrahub-observability"
@@ -95,10 +95,10 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
-      - uses: "azure/setup-helm@v4.3.0"
+      - uses: "azure/setup-helm@v5.0.0"
       - name: "Linting: helm lint infrahub-mcp"
         run: "helm lint charts/infrahub-mcp"
 
@@ -115,7 +115,7 @@ jobs:
       group: huge-runners
     timeout-minutes: 40
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
       - uses: "./.github/actions/setup-e2e"
@@ -129,7 +129,7 @@ jobs:
       group: huge-runners
     timeout-minutes: 40
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
       - uses: "./.github/actions/setup-e2e"
@@ -143,7 +143,7 @@ jobs:
       group: huge-runners
     timeout-minutes: 40
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
       - uses: "./.github/actions/setup-e2e"
@@ -157,7 +157,7 @@ jobs:
       group: huge-runners
     timeout-minutes: 40
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
       - uses: "./.github/actions/setup-e2e"
@@ -183,7 +183,7 @@ jobs:
       group: huge-runners
     timeout-minutes: 40
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
         with:
           submodules: true
       - uses: "./.github/actions/setup-e2e"

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -41,14 +41,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: opsmill/infrahub-helm
           ref: ${{ inputs.branch }}
           submodules: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@v5.0.0
 
       - name: Install yq
         uses: mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8 # v4.50.1


### PR DESCRIPTION
## Summary

Node.js 20 GitHub Actions are deprecated — they will be **forced to run on Node 24 starting June 16th, 2026**, and Node 20 is removed from runners on September 16th, 2026. This bumps every Node 20 JavaScript action in `.github/` to a release whose `action.yml` declares `using: node24` (verified against each action's source before bumping).

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v5` | node24 |
| `azure/setup-helm` | `@v4.3.0` | `@v5.0.0` | node24 |
| `azure/setup-kubectl` | `@v4` | `@v5` | node24 |
| `dorny/paths-filter` | `@v3` | `@v4` | node24 |

The deprecation warning only named `checkout` and `setup-helm`, but `setup-kubectl@v4` and `paths-filter@v3` are also Node 20 (just not surfaced in that run), so they're fixed here too.

## Files

- `.github/workflows/ci.yml`
- `.github/workflows/publish-helm-chart.yml`
- `.github/actions/setup-e2e/action.yml` (composite action)

## Notes

- These are major-version bumps (`v4→v5`); for these setup actions the v5 changes are the Node 24 migration plus newer default tool versions — no change to how they're invoked here.
- `setup-python@v6` and `setup-uv@v7` are already Node 24; `mikefarah/yq` is a Docker action (no Node concern).
- **Not fixable here:** `loft-sh/setup-vcluster` (pinned SHA in the e2e setup) is Node 20, but upstream has no Node 24 release — its only tag is `v0.0.1` (2023) and `main` is still Node 20. It'll be force-migrated to Node 24 with everything else until they publish a new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)