### PR TITLE
fix(neo4j): uncap resource limits to avoid OOMKills at an artificial cap

### DIFF
--- a/charts/infrahub-enterprise/Chart.yaml
+++ b/charts/infrahub-enterprise/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.10.0
+version: 4.11.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -27,5 +27,5 @@ appVersion: "1.9.7"
 
 dependencies:
   - name: infrahub
-    version: "4.24.0"
+    version: "4.25.0"
     repository: "oci://registry.opsmill.io/opsmill/chart"

--- a/charts/infrahub-enterprise/README.md
+++ b/charts/infrahub-enterprise/README.md
@@ -58,7 +58,7 @@ The chart offers the ability to configure persistence for the database and other
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.24.0 |
+| oci://registry.opsmill.io/opsmill/chart | infrahub | 4.25.0 |
 
 ## Values
 

--- a/charts/infrahub-enterprise/values.large-data.yaml
+++ b/charts/infrahub-enterprise/values.large-data.yaml
@@ -12,9 +12,6 @@ infrahub:
   neo4j:
     neo4j:
       resources:
-        limits:
-          cpu: "16"
-          memory: "64Gi"
         requests:
           cpu: "16"
           memory: "64Gi"

--- a/charts/infrahub-enterprise/values.large.yaml
+++ b/charts/infrahub-enterprise/values.large.yaml
@@ -12,9 +12,6 @@ infrahub:
   neo4j:
     neo4j:
       resources:
-        limits:
-          cpu: "16"
-          memory: "64Gi"
         requests:
           cpu: "16"
           memory: "64Gi"

--- a/charts/infrahub-enterprise/values.medium-data.yaml
+++ b/charts/infrahub-enterprise/values.medium-data.yaml
@@ -12,9 +12,6 @@ infrahub:
   neo4j:
     neo4j:
       resources:
-        limits:
-          cpu: "8"
-          memory: "32Gi"
         requests:
           cpu: "8"
           memory: "32Gi"

--- a/charts/infrahub-enterprise/values.medium.yaml
+++ b/charts/infrahub-enterprise/values.medium.yaml
@@ -12,9 +12,6 @@ infrahub:
   neo4j:
     neo4j:
       resources:
-        limits:
-          cpu: "8"
-          memory: "32Gi"
         requests:
           cpu: "8"
           memory: "32Gi"

--- a/charts/infrahub-enterprise/values.small.yaml
+++ b/charts/infrahub-enterprise/values.small.yaml
@@ -12,9 +12,6 @@ infrahub:
   neo4j:
     neo4j:
       resources:
-        limits:
-          cpu: "4"
-          memory: "16Gi"
         requests:
           cpu: "4"
           memory: "16Gi"

--- a/charts/infrahub/Chart.yaml
+++ b/charts/infrahub/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.24.0
+version: 4.25.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/infrahub/README.md
+++ b/charts/infrahub/README.md
@@ -196,8 +196,7 @@ The chart offers the ability to configure persistence for the database and other
 | neo4j.neo4j.minimumClusterSize | int | `1` |  |
 | neo4j.neo4j.name | string | `"infrahub"` |  |
 | neo4j.neo4j.password | string | `"admin"` |  |
-| neo4j.neo4j.resources.limits.cpu | string | `"4"` |  |
-| neo4j.neo4j.resources.limits.memory | string | `"8Gi"` |  |
+| neo4j.neo4j.resources.limits | object | `{}` |  |
 | neo4j.neo4j.resources.requests.cpu | string | `"2"` |  |
 | neo4j.neo4j.resources.requests.memory | string | `"4Gi"` |  |
 | neo4j.services.admin.enabled | bool | `false` |  |

--- a/charts/infrahub/values.yaml
+++ b/charts/infrahub/values.yaml
@@ -77,9 +77,10 @@ neo4j:
     minimumClusterSize: 1
     acceptLicenseAgreement: "no"
     resources:
-      limits:
-        cpu: "4"
-        memory: "8Gi"
+      # Neo4j's chart forces limits == requests when 'limits' is unset (nil).
+      # An explicit empty map is the only way to render the container with no
+      # resource limits, allowing Neo4j to burst above its requested memory.
+      limits: {}
       requests:
         cpu: "2"
         memory: "4Gi"


### PR DESCRIPTION
## What

Uncap the neo4j container's resource **limits**:

- `charts/infrahub/values.yaml` — neo4j `resources.limits` → `{}`
- `charts/infrahub-enterprise/values.{small,medium,medium-data,large,large-data}.yaml` — drop the explicit `limits` blocks from the neo4j presets (requests unchanged)
- helm-docs READMEs regenerated
- Version bumps: infrahub `4.24.0 → 4.25.0`, infrahub-enterprise `4.10.0 → 4.11.0` (+ infrahub dependency pin)

## Why

To avoid neo4j being **OOMKilled when it hits an artificial cap**. Removing the limit lets neo4j burst above its requested memory; the JVM heap/pagecache stay bounded by the `server.memory.*` config in each preset, so the process is still constrained where it matters.

## The non-obvious bit

The Neo4j subchart's `checkForEmptyResources` helper does `set ... "limits" $requests` whenever `limits` is **nil**. So simply deleting the key does *not* uncap — it forces `limits == requests`. An explicit empty map (`limits: {}`) is the one value the helper leaves alone, and it renders as `resources.limits: {}` (= no cap). Verified by rendering the statefulset.

## ⚠️ Release ordering

The enterprise preset changes only take effect once the vendored `infrahub` dependency is refreshed to a `4.25.0` build carrying this change. The Chart.lock / vendored tgz currently still pin `4.21.6`, whose neo4j default has a real `8Gi` limit — building/releasing enterprise against that *with the preset limits already removed* would render `limits(8Gi) < requests` and the pod would be rejected. Refresh the dependency (`helm dependency update`) as part of the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
